### PR TITLE
WorldClockTab: add 24/12 hour toggle, and date

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,9 @@ limitations under the License.
 */
 
 import 'dart:async';
+import 'dart:ffi';
 import 'dart:ui';
+import 'package:intl/intl.dart';
 
 import 'package:flutter/material.dart';
 
@@ -148,6 +150,8 @@ class WorldClockTab extends StatefulWidget {
 
 class _WorldClockTabState extends State<WorldClockTab> {
   DateTime _datetime = DateTime.now();
+  String _dateTimeString = "";
+  bool is24 = true;
   Timer? _ctimer;
 
   @override
@@ -158,17 +162,39 @@ class _WorldClockTabState extends State<WorldClockTab> {
 
   @override
   Widget build(BuildContext context) {
+    if (!is24)
+      _dateTimeString = DateFormat('hh:mm a').format(DateTime.now()).toString();
+    else
+      _dateTimeString =
+          "${_datetime.hour}:${_datetime.minute < 10 ? "0" + _datetime.minute.toString() : _datetime.minute}:${_datetime.second < 10 ? "0" + _datetime.second.toString() : _datetime.second}";
+
     if (_ctimer == null)
       _ctimer = Timer.periodic(Duration(seconds: 1), (me) {
-        _datetime = DateTime.now();
         setState(() {});
       });
     return Material(
-      child: Center(
-          child: Text(
-        "${_datetime.hour}:${_datetime.minute < 10 ? "0" + _datetime.minute.toString() : _datetime.minute}:${_datetime.second < 10 ? "0" + _datetime.second.toString() : _datetime.second}",
-        style: TextStyle(fontSize: 48, fontWeight: FontWeight.bold),
-      )),
+      child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+        Text(
+          this._dateTimeString,
+          style: TextStyle(fontSize: 48, fontWeight: FontWeight.bold),
+        ),
+        Text(
+          DateFormat.yMMMMd('en_US').format(DateTime.now()),
+          style: TextStyle(fontSize: 28, fontWeight: FontWeight.w500),
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text("24-hour format"),
+            Switch(
+                value: is24,
+                onChanged: (bool value) {
+                  this._dateTimeString = DateTime.now().toString();
+                  is24 = !is24;
+                }),
+          ],
+        ),
+      ]),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,32 +113,37 @@ class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
                       showDialog(
                         context: context,
                         builder: (BuildContext context) {
-                          return AlertDialog(
-                            title: Text("Settings"),
-                            content: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                SwitchListTile(
-                                  title: Text("24-hour format"),
-                                  subtitle: Text("This setting is not persisted yet."),
-                                  value: use24HourFormat,
-                                  onChanged: (bool value) {
-                                    //this._dateTimeString = DateTime.now().toString();
-                                    setState(() {
-                                      use24HourFormat = !use24HourFormat;
-                                    });
-                                  }
+                          return StatefulBuilder(
+                            builder: (context, setState2) {
+                              return AlertDialog(
+                                title: Text("Settings"),
+                                content: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    SwitchListTile(
+                                      title: Text("24-hour format"),
+                                      subtitle: Text("At this time, settings will be cleared when the app is closed."),
+                                      value: use24HourFormat,
+                                      onChanged: (bool newValue) {
+                                        //this._dateTimeString = DateTime.now().toString();
+                                        setState(() {
+                                          use24HourFormat = newValue;
+                                        });
+                                        setState2(() {});
+                                      }
+                                    ),
+                                  ],
                                 ),
-                              ],
-                            ),
-                            actions: [
-                              TextButton(
-                                child: Text("OK"),
-                                onPressed: () {
-                                  Navigator.of(context).pop();
-                                },
-                              ),
-                            ],
+                                actions: [
+                                  TextButton(
+                                    child: Text("OK"),
+                                    onPressed: () {
+                                      Navigator.of(context).pop();
+                                    },
+                                  ),
+                                ],
+                              );
+                            }
                           );
                         },
                       );
@@ -167,7 +172,7 @@ class WorldClockTab extends StatefulWidget {
 }
 
 class _WorldClockTabState extends State<WorldClockTab> {
-  DateTime _datetime = DateTime.now();
+  //DateTime _datetime = DateTime.now();
   String _dateTimeString = "";
   Timer? _ctimer;
 
@@ -180,10 +185,11 @@ class _WorldClockTabState extends State<WorldClockTab> {
   @override
   Widget build(BuildContext context) {
     if (!widget.use24HourFormat)
-      _dateTimeString = DateFormat('hh:mm a').format(DateTime.now()).toString();
+      _dateTimeString = DateFormat.jms().format(DateTime.now()).toString();
     else
-      _dateTimeString =
-          "${_datetime.hour}:${_datetime.minute < 10 ? "0" + _datetime.minute.toString() : _datetime.minute}:${_datetime.second < 10 ? "0" + _datetime.second.toString() : _datetime.second}";
+      _dateTimeString = DateFormat.Hms().format(DateTime.now()).toString();
+      // _dateTimeString =
+      //     "${_datetime.hour}:${_datetime.minute < 10 ? "0" + _datetime.minute.toString() : _datetime.minute}:${_datetime.second < 10 ? "0" + _datetime.second.toString() : _datetime.second}";
 
     if (_ctimer == null)
       _ctimer = Timer.periodic(Duration(seconds: 1), (me) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,13 +60,15 @@ class ClockApp extends StatefulWidget {
 }
 
 class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
+  bool use24HourFormat = false;
+
   @override
   Widget build(BuildContext context) {
     final TabController tcon = TabController(length: 3, vsync: this);
 
     final KeyboardEvents keyboardEvents = KeyboardEvents();
 
-    return new RawKeyboardListener(
+    return RawKeyboardListener(
         focusNode: FocusNode(skipTraversal: true),
         autofocus: true,
         onKey: keyboardEvents.onKey,
@@ -111,14 +113,27 @@ class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
                       showDialog(
                         context: context,
                         builder: (BuildContext context) {
-                          // return object of type Dialog
                           return AlertDialog(
-                            title: new Text("Error"),
-                            content: new Text("ERROR FEATURE NOT IMPLEMENTED"),
-                            actions: <Widget>[
-                              // usually buttons at the bottom of the dialog
-                              new FlatButton(
-                                child: new Text("OK"),
+                            title: Text("Settings"),
+                            content: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                SwitchListTile(
+                                  title: Text("24-hour format"),
+                                  subtitle: Text("This setting is not persisted yet."),
+                                  value: use24HourFormat,
+                                  onChanged: (bool value) {
+                                    //this._dateTimeString = DateTime.now().toString();
+                                    setState(() {
+                                      use24HourFormat = !use24HourFormat;
+                                    });
+                                  }
+                                ),
+                              ],
+                            ),
+                            actions: [
+                              TextButton(
+                                child: Text("OK"),
                                 onPressed: () {
                                   Navigator.of(context).pop();
                                 },
@@ -135,7 +150,7 @@ class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
             body: TabBarView(
               controller: tcon,
               children: [
-                WorldClockTab(),
+                WorldClockTab(use24HourFormat: use24HourFormat),
                 AlarmsTab(),
                 TimerTab(keyboardEvents: keyboardEvents)
               ],
@@ -144,6 +159,9 @@ class _ClockApp extends State<ClockApp> with TickerProviderStateMixin {
 }
 
 class WorldClockTab extends StatefulWidget {
+  final bool use24HourFormat;
+  WorldClockTab({Key? key, this.use24HourFormat = false}) : super(key: key);
+
   @override
   _WorldClockTabState createState() => _WorldClockTabState();
 }
@@ -151,7 +169,6 @@ class WorldClockTab extends StatefulWidget {
 class _WorldClockTabState extends State<WorldClockTab> {
   DateTime _datetime = DateTime.now();
   String _dateTimeString = "";
-  bool is24 = true;
   Timer? _ctimer;
 
   @override
@@ -162,7 +179,7 @@ class _WorldClockTabState extends State<WorldClockTab> {
 
   @override
   Widget build(BuildContext context) {
-    if (!is24)
+    if (!widget.use24HourFormat)
       _dateTimeString = DateFormat('hh:mm a').format(DateTime.now()).toString();
     else
       _dateTimeString =
@@ -181,18 +198,6 @@ class _WorldClockTabState extends State<WorldClockTab> {
         Text(
           DateFormat.yMMMMd('en_US').format(DateTime.now()),
           style: TextStyle(fontSize: 28, fontWeight: FontWeight.w500),
-        ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text("24-hour format"),
-            Switch(
-                value: is24,
-                onChanged: (bool value) {
-                  this._dateTimeString = DateTime.now().toString();
-                  is24 = !is24;
-                }),
-          ],
         ),
       ]),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -60,6 +60,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   matcher:
     dependency: transitive
     description:
@@ -73,7 +80,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -99,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -135,12 +142,19 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
 sdks:
   dart: ">=2.14.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,34 +120,27 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.17.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Description

- The clock tab of the app did not have a toggle to choose 24-hour or 12-hour time. Added a switch so that the user can choose one. 
- The app now shows the current date along with the time.
- A new dependency - `intl` package was added for formatting the date 

## Screenshots:
![image](https://user-images.githubusercontent.com/73262131/163809555-fc1215da-e345-4f92-97b7-564d52e598ab.png)
![image](https://user-images.githubusercontent.com/73262131/163809580-9cba68e2-4770-4b2c-bd05-a2790b94c449.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Fixes issue #4 
## Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
